### PR TITLE
Patch 1

### DIFF
--- a/manuscript/manuscript.Rmd
+++ b/manuscript/manuscript.Rmd
@@ -516,7 +516,7 @@ directory (Box 1).
 
 ```bash
 sudo apt update && sudo apt install docker.io -y  # 30 sec
-sudo docker run -it --platform linux/amd64 mziemann/enrichment_recipe Rscript -e 'rmarkdown::render("example.Rmd")'
+sudo docker run -it --platform linux/amd64 mziemann/enrichment_recipe Rscript -e 'rmarkdown::render("example.Rmd")' # 150 sec
 docker cp $(docker ps -aql):/enrichment_recipe/example.html . # instant
 firefox example.html
 ```

--- a/manuscript/manuscript.Rmd
+++ b/manuscript/manuscript.Rmd
@@ -516,7 +516,7 @@ directory (Box 1).
 
 ```bash
 sudo apt update && sudo apt install docker.io -y  # 30 sec
-sudo docker run -it --platform linux/amd64 mziemann/enrichment_recipe Rscript -e 'rmarkdown::render("example.Rmd")' # 150 sec
+sudo docker run --platform linux/amd64 mziemann/enrichment_recipe Rscript -e 'rmarkdown::render("example.Rmd")' # 150 sec
 docker cp $(docker ps -aql):/enrichment_recipe/example.html . # instant
 firefox example.html
 ```

--- a/manuscript/manuscript.Rmd
+++ b/manuscript/manuscript.Rmd
@@ -516,9 +516,7 @@ directory (Box 1).
 
 ```bash
 sudo apt update && sudo apt install docker.io -y  # 30 sec
-sudo docker run -it --entrypoint /bin/bash mziemann/enrichment_recipe #60 sec
-Rscript -e 'rmarkdown::render("example.Rmd")' # 90 sec
-exit
+sudo docker run -it --platform linux/amd64 mziemann/enrichment_recipe Rscript -e 'rmarkdown::render("example.Rmd")'
 docker cp $(docker ps -aql):/enrichment_recipe/example.html . # instant
 firefox example.html
 ```


### PR DESCRIPTION
the entrypoint is unnecessary, docker containers take bash commands directly
as the image is not a multiplatform build reproduction on a Mac requires stating an alternative platform explicitly but this shouldnt hurt on linux